### PR TITLE
Origin/production/cci v3p0

### DIFF
--- a/pysiral/auxdata/ml.py
+++ b/pysiral/auxdata/ml.py
@@ -250,7 +250,7 @@ class RetrackerThresholdModelTorch(AuxdataBaseClass):
             start = spacing + 1
             h_a = x[start:start + bins]  # after
             
-            peak_candidate = np.logical_and(h_c > h_b, h_c > h_a)
+            peak_candidate = np.logical_and(h_c > h_b, h_c >= h_a)
             peak_candidate = np.logical_and(peak_candidate, np.arange(bins) > 10)
             peak_candidate = np.logical_and(peak_candidate, wfm > 0.5)
 

--- a/pysiral/retracker.py
+++ b/pysiral/retracker.py
@@ -1514,7 +1514,8 @@ class ERSPulseDeblurring(Level2ProcessorStep):
         eps = l2.epss * 0.5 * 299792458.
 
         # Compute and apply pulse deblurring correction
-        pulse_deblurring_correction = np.array(eps < 0.).astype(float) * eps / 5.0
+        slope = self.constant_slope
+        pulse_deblurring_correction = np.array(eps < 0.).astype(float) * eps / slope
         for target_variable in self.target_variables:
             var = l2.get_parameter_by_name(target_variable)
             var[:] = var[:] + pulse_deblurring_correction
@@ -1541,6 +1542,12 @@ class ERSPulseDeblurring(Level2ProcessorStep):
     @property
     def error_bit(self):
         return self.error_flag_bit_dict["retracker"]
+
+    @property
+    def constant_slope(self):
+        #return slope term depending on ERS mission
+        #defaults to 5.0, the ERS-2 value
+        return self.cfg.options.get("slope", 5.0)
 
 
 class SGDRMultipleElevations(Level2ProcessorStep):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ attrdict
 bottleneck
 cftime
 cython
-dateperiods @ git+https://github.com/shendric/dateperiods.git@master#egg=dateperiods
+dateperiods @ git+https://github.com/shendric/dateperiods.git@main#egg=dateperiods
 dateutils
 flake8
 geopy


### PR DESCRIPTION
Updates on the `auxdata/ml.py` and `retracker.py`, primarily allowing the use of a `slope` parameter in the L2 settings files within the `retracker` module `ERSPulseDeblurring` subclass options. Defaults still to the ERS2 standard of 5.0 but allows for an easy change for ERS1 or for other reasons.